### PR TITLE
fix(lexer): add missing tokens

### DIFF
--- a/compiler/front/bfc_lexer/src/lexer.rs
+++ b/compiler/front/bfc_lexer/src/lexer.rs
@@ -205,6 +205,7 @@ impl<'s> Lexer<'s> {
             (TokenType::Minus, TokenType::Minus) => TokenType::MinusMinus,  // --
 
             (TokenType::Minus, TokenType::RAngle) => TokenType::Arrow, // ->
+            (TokenType::Colon, TokenType::Colon) => TokenType::DoubleColon, // ::
 
             _ => {
                 return None;
@@ -379,7 +380,7 @@ mod tests {
 
     #[test]
     fn test_merged() {
-        let mut lexer = Lexer::new("&& || ++ -- == != <= >= += -= *= /= %= ->");
+        let mut lexer = Lexer::new("&& || ++ -- == != <= >= += -= *= /= %= -> ::");
 
         test_token_stream!(
             lexer,
@@ -396,7 +397,8 @@ mod tests {
             TokenType::StarAssign,
             TokenType::SlashAssign,
             TokenType::PercentAssign,
-            TokenType::Arrow
+            TokenType::Arrow,
+            TokenType::DoubleColon
         );
     }
 

--- a/compiler/front/bfc_lexer/src/token.rs
+++ b/compiler/front/bfc_lexer/src/token.rs
@@ -54,7 +54,8 @@ pub enum TokenType {
     LAngle,    // <
     RAngle,    // >
 
-    Arrow, // ->
+    Arrow,       // ->
+    DoubleColon, // ::
 
     // Keywords
     Const, // const


### PR DESCRIPTION
Changes:
* Added `DoubleColon` (`::`)
* Added test for `Arrow` (`->`)