### PR TITLE
feat(lexer): make lexer output an infinite stream

### DIFF
--- a/compiler/front/bfc_lexer/src/error.rs
+++ b/compiler/front/bfc_lexer/src/error.rs
@@ -1,5 +1,6 @@
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenError {
+    UnknownCharacter(char),
     InvalidToken,
     UnclosedString,
 }

--- a/compiler/front/bfc_lexer/src/lexer.rs
+++ b/compiler/front/bfc_lexer/src/lexer.rs
@@ -4,13 +4,13 @@ use bfc_span::span::{BytePos, Span};
 use std::iter::Peekable;
 use std::str::CharIndices;
 
-struct Lexer<'s> {
+pub struct Lexer<'s> {
     chars: Peekable<CharIndices<'s>>,
     end: usize,
 }
 
 impl<'s> Lexer<'s> {
-    fn new(input: &'s str) -> Lexer {
+    pub fn new(input: &'s str) -> Lexer {
         Lexer {
             chars: input.char_indices().peekable(),
             end: input.len(),

--- a/compiler/front/bfc_lexer/src/lexer.rs
+++ b/compiler/front/bfc_lexer/src/lexer.rs
@@ -432,4 +432,18 @@ mod tests {
             TokenType::Pub
         );
     }
+
+    #[test]
+    fn test_eof() {
+        let mut lexer = Lexer::new("fn");
+
+        test_token_stream!(
+            lexer,
+            TokenType::Fn,
+            TokenType::Eof,
+            TokenType::Eof,
+            TokenType::Eof,
+            TokenType::Eof
+        );
+    }
 }


### PR DESCRIPTION
Changes:
* The lexer now outputs an infinite stream of EOFs after the last token